### PR TITLE
feat: Remove duplicate back button

### DIFF
--- a/app/meal.tsx
+++ b/app/meal.tsx
@@ -18,9 +18,6 @@ export default function MealScreen() {
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
-        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
-          <Ionicons name="arrow-back" size={24} color="black" />
-        </TouchableOpacity>
         <Text style={styles.title}>Recipes for {meal}</Text>
         <ScrollView contentContainerStyle={styles.scrollViewContent}>
           {recipeList.map((recipe, index) => (
@@ -44,9 +41,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 20,
-  },
-  backButton: {
-    marginBottom: 20,
   },
   title: {
     fontSize: 24,

--- a/app/suggestions.tsx
+++ b/app/suggestions.tsx
@@ -65,9 +65,6 @@ export default function SuggestionsScreen() {
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
-        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
-          <Ionicons name="arrow-back" size={24} color="black" />
-        </TouchableOpacity>
         <Text style={styles.title}>Here are some suggestions for when you're feeling {mood.toLowerCase()}:</Text>
 
         <ScrollView contentContainerStyle={styles.scrollViewContent}>
@@ -92,9 +89,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 20,
-  },
-  backButton: {
-    marginBottom: 20,
   },
   title: {
     fontSize: 24,


### PR DESCRIPTION
Removes the manually implemented back button from the `meal` and `suggestions` screens. The `expo-router` Stack navigator already provides a back button, so the manual implementation was redundant.